### PR TITLE
Add 'Connection: close' header to health check request

### DIFF
--- a/service/healthz/kvm/kvm.go
+++ b/service/healthz/kvm/kvm.go
@@ -27,6 +27,7 @@ const (
 	k8sAPIPort        = 443
 	k8sKubeletPort    = 10248
 	maxIdleConnection = 10
+	maxTimeout        = 4
 )
 
 // Config represents the configuration used to create a healthz service.
@@ -61,14 +62,21 @@ func New(config Config) (*Service, error) {
 	}
 
 	tr := &http.Transport{
-		MaxConnsPerHost: maxIdleConnection,
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		MaxConnsPerHost:   maxIdleConnection,
+		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+		DisableKeepAlives: true,
+		IdleConnTimeout:   maxTimeout,
+	}
+
+	client := &http.Client{
+		Transport: tr,
+		Timeout:   maxTimeout,
 	}
 
 	newService := &Service{
 		// Dependencies.
 		checkAPI: config.CheckAPI,
-		client:   &http.Client{Transport: tr},
+		client:   client,
 		ip:       config.IP,
 		logger:   config.Logger,
 		tr:       tr,

--- a/service/healthz/kvm/kvm.go
+++ b/service/healthz/kvm/kvm.go
@@ -61,12 +61,8 @@ func New(config Config) (*Service, error) {
 		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
 	}
 
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-
 	client := &http.Client{
-		Transport: tr,
+		Timeout: maxTimeout,
 	}
 
 	newService := &Service{
@@ -75,7 +71,6 @@ func New(config Config) (*Service, error) {
 		client:   client,
 		ip:       config.IP,
 		logger:   config.Logger,
-		tr:       tr,
 	}
 
 	return newService, nil
@@ -151,6 +146,7 @@ func (s *Service) httpHealthCheck(port int, scheme string) (bool, string) {
 	}
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		MaxIdleConns:    maxIdleConnection,
 	}
 	// be sure to close idle connection after health check is finished
 	defer tr.CloseIdleConnections()

--- a/service/healthz/kvm/kvm.go
+++ b/service/healthz/kvm/kvm.go
@@ -27,7 +27,7 @@ const (
 	k8sAPIPort        = 443
 	k8sKubeletPort    = 10248
 	maxIdleConnection = 10
-	maxTimeout        = 4
+	maxTimeoutSec     = 4
 )
 
 // Config represents the configuration used to create a healthz service.
@@ -63,10 +63,12 @@ func New(config Config) (*Service, error) {
 
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		MaxIdleConns:    maxIdleConnection,
 	}
 
 	client := &http.Client{
 		Transport: tr,
+		Timeout:   maxTimeoutSec * time.Second,
 	}
 
 	newService := &Service{

--- a/service/healthz/kvm/kvm.go
+++ b/service/healthz/kvm/kvm.go
@@ -62,15 +62,11 @@ func New(config Config) (*Service, error) {
 	}
 
 	tr := &http.Transport{
-		MaxConnsPerHost:   maxIdleConnection,
-		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
-		DisableKeepAlives: true,
-		IdleConnTimeout:   maxTimeout,
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 
 	client := &http.Client{
 		Transport: tr,
-		Timeout:   maxTimeout,
 	}
 
 	newService := &Service{
@@ -153,8 +149,13 @@ func (s *Service) httpHealthCheck(port int, scheme string) (bool, string) {
 		Path:   "healthz",
 		Scheme: scheme,
 	}
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
 	// be sure to close idle connection after health check is finished
-	defer s.tr.CloseIdleConnections()
+	defer tr.CloseIdleConnections()
+
+	s.client.Transport = tr
 
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {


### PR DESCRIPTION
Idle HTTP connections (that would otherwise wait in keep-alive state) are
closed in defer function after exiting httpHealthCheck() so add explicit
connection closing to HTTP request in order to be clear about intentions with
other endpoint.